### PR TITLE
rc-v0.1.0

### DIFF
--- a/display-posts-shortcode-remote.php
+++ b/display-posts-shortcode-remote.php
@@ -21,8 +21,8 @@
  */
 
 /**
- * author Ramin Farhadi
- * since 0.1.0ß
+ * Forked by Ramin Farhadi
+ * since 0.1.0
  */
 
 if ( ! class_exists( 'Display_Posts_Remote' ) ) {

--- a/display-posts-shortcode-remote.php
+++ b/display-posts-shortcode-remote.php
@@ -20,6 +20,11 @@
  * Domain Path:       /languages
  */
 
+/**
+ * author Ramin Farhadi
+ * since 0.1.0ß
+ */
+
 if ( ! class_exists( 'Display_Posts_Remote' ) ) {
 
 	final class Display_Posts_Remote {
@@ -227,10 +232,10 @@ if ( ! class_exists( 'Display_Posts_Remote' ) ) {
 		 * @return array|WP_Error
 		 */
 		public function getPosts( $untrusted ) {
-
+			//Category Id was disabled in order to list all the posts available.  
 			$defaults = array(
 				'url'           => '',
-				'category_id'   => 0,
+				// 'category_id'   => 0,
 				'per_page'      => 10,
 				'order'         => 'DESC',
 				'orderby'       => 'date',

--- a/display-posts-shortcode-remote.php
+++ b/display-posts-shortcode-remote.php
@@ -232,15 +232,17 @@ if ( ! class_exists( 'Display_Posts_Remote' ) ) {
 		 * @return array|WP_Error
 		 */
 		public function getPosts( $untrusted ) {
-			//Category Id was disabled in order to list all the posts available.  
-			$defaults = array(
-				'url'           => '',
-				// 'category_id'   => 0,
-				'per_page'      => 10,
-				'order'         => 'DESC',
-				'orderby'       => 'date',
-				'cache_timeout' => DAY_IN_SECONDS,
-			);
+			
+				$defaults = array(
+					'url'           => '',
+					'category_id'	=> '',
+					'per_page'      => 10,
+					'order'         => 'DESC',
+					'orderby'       => 'date',
+					'cache_timeout' => DAY_IN_SECONDS,
+				);
+		
+			
 
 			$atts = shortcode_atts( $defaults, $untrusted );
 
@@ -324,7 +326,7 @@ if ( ! class_exists( 'Display_Posts_Remote' ) ) {
 		public function getDefaults() {
 
 			return array(
-				'category_id'           => 0,
+				'category_id'           => '',
 				'content_class'         => 'content',
 				'date_format'           => '(n/j/Y)',
 				'include_content'       => FALSE,


### PR DESCRIPTION
<!---
Thank you for contributing to Display-posts-shortcode-remote
-->

**Description**

This is the Forked version of [display-posts-shortcode-remote](https://github.com/shazahm1/Display-Posts-Shortcode-Remote) . 

**Motivation and Context**
By default, the plugin adds category_id = 0 if we don't provide the category_id attribute in the shortcode. As a result, no posts were pulling from the remote. By removing or commenting out that parameter, the plugin will pull posts from all categories unless we specify a specific category.

**How Has This Been Tested?**
Changes have been tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
